### PR TITLE
Update islands track from full to dense

### DIFF
--- a/EMS/ems/app/controller/Experiment/Experiment.js
+++ b/EMS/ems/app/controller/Experiment/Experiment.js
@@ -421,11 +421,12 @@ Ext.define('EMS.controller.Experiment.Experiment', {
      ***********************************************************************/
     addGB: function (tab) {
 
-        var gtbl = this.UID.replace(/-/g, '_') + '_wtrack';
-        if (!this.isRNA) {
-            gtbl = this.UID.replace(/-/g, '_') + '_grp';
+        var wtrack_tbl = this.UID.replace(/-/g, '_') + '_wtrack';
+        var islands_tbl = this.UID.replace(/-/g, '_') + '_islands';
+        var url = EMS.util.Util.Settings('genomebrowserroot') + '/cgi-bin/hgTracks?db=' + this.db + '&pix=1050&refGene=full&' + wtrack_tbl + '=full&' + islands_tbl + '=dense';
+        if (this.isRNA) {
+            url = EMS.util.Util.Settings('genomebrowserroot') + '/cgi-bin/hgTracks?db=' + this.db + '&pix=1050&refGene=full&' + wtrack_tbl + '=full';
         }
-        var url = EMS.util.Util.Settings('genomebrowserroot') + '/cgi-bin/hgTracks?db=' + this.db + '&pix=1050&refGene=full&' + gtbl + '=full';
         tab.add({
                     title: 'Genome browser',
                     iconCls: 'genome-browser',


### PR DESCRIPTION
When displaying genome coverage and
islands tracks as a composite track
for DNA-Seq we set visibility to Full
for the whole composite track. It means
that both _islands and _wtrack are Full.
Now Full is changed to Dense for _islands